### PR TITLE
Adding new lifecycle policy to control the expiration of noncurrent versions

### DIFF
--- a/groups/infrastructure/s3.tf
+++ b/groups/infrastructure/s3.tf
@@ -19,9 +19,24 @@ module "heritage_staging_chips_backup" {
     enabled = true
   }
 
-  # lifecycle_rule = [
-  #   #Long term cold backup, we should have data lifecycle/tiering
-  # ]
+  lifecycle_rule = [
+    {
+      id                                     = "VersionsManagement"
+      enabled                                = true
+      abort_incomplete_multipart_upload_days = 7
+
+      noncurrent_version_transition = [
+        {
+          days          = 30
+          storage_class = "STANDARD_IA"
+        }
+      ]
+
+      noncurrent_version_expiration = {
+        days = 60
+      }
+    }
+  ]
 
   server_side_encryption_configuration = {
     rule = {


### PR DESCRIPTION
Adding new lifecycle policy to control the expiration of noncurrent version files (old versions of existing files) to ensure the bucket does not get bloated