### PR TITLE
Add a custom IAM password policy

### DIFF
--- a/groups/infrastructure/main.tf
+++ b/groups/infrastructure/main.tf
@@ -29,3 +29,11 @@ provider "vault" {
     }
   }
 }
+
+####################################################################################################
+## IAM Password Policy
+####################################################################################################
+
+module "iam_password_policy" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/iam_password_policy?ref=tags/1.0.247"
+}


### PR DESCRIPTION
Security remediation - adds a stricter custom password policy, that overrides the default for the following:

minimum_password_length = 14
password_reuse_prevention = 24 (can't reuse password)
max_password_age = 90 (expires after 90 days, and so users have to change password on next login)

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2786
