### PR TITLE
Enable Cloudtrail logging to CloudWatch and CIS alerting

### DIFF
--- a/groups/infrastructure/locals.tf
+++ b/groups/infrastructure/locals.tf
@@ -9,6 +9,8 @@ locals {
   cloudtrail_prefix    = "cloudtrail-logs"
   vpc_flow_logs_prefix = "flow-logs"
 
+  cloudwatch_log_group_for_cloudtrail = "/cloudtrail/${var.aws_account}-${var.region}"
+
   internal_fqdn = "${var.aws_account}.${var.private_domain}"
 
   default_tags = {

--- a/groups/infrastructure/main.tf
+++ b/groups/infrastructure/main.tf
@@ -37,3 +37,20 @@ provider "vault" {
 module "iam_password_policy" {
   source = "git@github.com:companieshouse/terraform-modules//aws/iam_password_policy?ref=tags/1.0.247"
 }
+
+####################################################################################################
+## CloudTrail CIS alerting
+## Configures an SNS Topic and a number of metric filters and alarms to alert on specific changes.
+####################################################################################################
+
+module "cloudtrail_cis_alerting" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/cloudtrail_cis_alerting?ref=tags/1.0.257"
+
+  aws_profile    = "${var.aws_account}-${var.aws_region}"
+  account        = var.account
+  region         = var.region
+  log_group_name = local.cloudwatch_log_group_for_cloudtrail
+  tags           = local.default_tags
+
+  depends_on = [module.cloudtrail]
+}

--- a/groups/infrastructure/security.tf
+++ b/groups/infrastructure/security.tf
@@ -28,6 +28,9 @@ module "cloudtrail" {
   s3_bucket_name = local.security_s3["cloudtrail-bucket-name"]
   s3_key_prefix  = local.cloudtrail_prefix
 
+  cloudwatch_logging        = true
+  cloudwatch_log_group_name = local.cloudwatch_log_group_for_cloudtrail
+
   kms_key = local.security_kms["cloudtrail-kms-key-arn"]
 
   event_selector = [


### PR DESCRIPTION
Enables CloudTrail logging to CloudWatch for SecurityHub control "[CloudTrail.5] - CloudTrail trails should be integrated with Amazon CloudWatch Logs"

Also references the module cloudtrail_cis_alerting (https://github.com/companieshouse/terraform-modules/tree/main/aws/cloudtrail_cis_alerting) to enable alerting on certain events, as per https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2794 (CloudTrail logging)
https://companieshouse.atlassian.net/browse/DVOP-2808 (Alerting on events)
