### PR TITLE
Update infrastructure TF and Provider Versions

### DIFF
--- a/groups/infrastructure/README.md
+++ b/groups/infrastructure/README.md
@@ -5,28 +5,30 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0, < 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 0.3, < 4.0 |
-| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >= 2.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 6.0 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >= 4.0, < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 0.3, < 4.0 |
-| <a name="provider_vault"></a> [vault](#provider\_vault) | >= 2.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 6.0 |
+| <a name="provider_vault"></a> [vault](#provider\_vault) | >= 4.0, < 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | git@github.com:companieshouse/terraform-modules//aws/cloudtrail?ref=tags/1.0.99 |  |
-| <a name="module_config"></a> [config](#module\_config) | git@github.com:companieshouse/terraform-modules//aws/config?ref=tags/1.0.63 |  |
-| <a name="module_heritage_live_chips_backup"></a> [heritage\_live\_chips\_backup](#module\_heritage\_live\_chips\_backup) | terraform-aws-modules/s3-bucket/aws | 2.11.1 |
-| <a name="module_heritage_live_chips_backup_policy"></a> [heritage\_live\_chips\_backup\_policy](#module\_heritage\_live\_chips\_backup\_policy) | git@github.com:companieshouse/terraform-modules//aws/s3_cross_account_policy?ref=tags/1.0.137 |  |
-| <a name="module_heritage_staging_chips_backup"></a> [heritage\_staging\_chips\_backup](#module\_heritage\_staging\_chips\_backup) | terraform-aws-modules/s3-bucket/aws | 2.11.1 |
-| <a name="module_heritage_staging_chips_backup_policy"></a> [heritage\_staging\_chips\_backup\_policy](#module\_heritage\_staging\_chips\_backup\_policy) | git@github.com:companieshouse/terraform-modules//aws/s3_cross_account_policy?ref=tags/1.0.137 |  |
-| <a name="module_kms"></a> [kms](#module\_kms) | git@github.com:companieshouse/terraform-modules//aws/kms?ref=tags/1.0.56 |  |
+| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | git@github.com:companieshouse/terraform-modules//aws/cloudtrail | tags/1.0.267 |
+| <a name="module_cloudtrail_cis_alerting"></a> [cloudtrail\_cis\_alerting](#module\_cloudtrail\_cis\_alerting) | git@github.com:companieshouse/terraform-modules//aws/cloudtrail_cis_alerting | tags/1.0.267 |
+| <a name="module_config"></a> [config](#module\_config) | git@github.com:companieshouse/terraform-modules//aws/config | tags/1.0.267 |
+| <a name="module_heritage_live_chips_backup"></a> [heritage\_live\_chips\_backup](#module\_heritage\_live\_chips\_backup) | terraform-aws-modules/s3-bucket/aws | 4.0.1 |
+| <a name="module_heritage_live_chips_backup_policy"></a> [heritage\_live\_chips\_backup\_policy](#module\_heritage\_live\_chips\_backup\_policy) | git@github.com:companieshouse/terraform-modules//aws/s3_cross_account_policy | tags/1.0.267 |
+| <a name="module_heritage_staging_chips_backup"></a> [heritage\_staging\_chips\_backup](#module\_heritage\_staging\_chips\_backup) | terraform-aws-modules/s3-bucket/aws | 4.0.1 |
+| <a name="module_heritage_staging_chips_backup_policy"></a> [heritage\_staging\_chips\_backup\_policy](#module\_heritage\_staging\_chips\_backup\_policy) | git@github.com:companieshouse/terraform-modules//aws/s3_cross_account_policy | tags/1.0.267 |
+| <a name="module_iam_password_policy"></a> [iam\_password\_policy](#module\_iam\_password\_policy) | git@github.com:companieshouse/terraform-modules//aws/iam_password_policy | tags/1.0.267 |
+| <a name="module_kms"></a> [kms](#module\_kms) | git@github.com:companieshouse/terraform-modules//aws/kms | tags/1.0.267 |
 
 ## Resources
 

--- a/groups/infrastructure/kms.tf
+++ b/groups/infrastructure/kms.tf
@@ -1,8 +1,7 @@
-
 module "kms" {
   for_each = local.kms_customer_master_keys
 
-  source                  = "git@github.com:companieshouse/terraform-modules//aws/kms?ref=tags/1.0.56"
+  source                  = "git@github.com:companieshouse/terraform-modules//aws/kms?ref=tags/1.0.267"
   kms_key_alias           = "${var.account}/${var.region}/${each.key}"
   description             = lookup(each.value, "description", "${var.account}/${var.region}/${each.key}")
   deletion_window_in_days = lookup(each.value, "deletion_window_in_days", 30)
@@ -18,9 +17,9 @@ module "kms" {
 
   tags = merge(
     local.default_tags,
-    map(
-      "Account", var.aws_account,
-      "ServiceTeam", "Platform"
-    )
+    {
+      "Account" = var.aws_account,
+      "ServiceTeam" = "Platform"
+    }
   )
 }

--- a/groups/infrastructure/kms.tf
+++ b/groups/infrastructure/kms.tf
@@ -18,7 +18,7 @@ module "kms" {
   tags = merge(
     local.default_tags,
     {
-      "Account" = var.aws_account,
+      "Account"     = var.aws_account,
       "ServiceTeam" = "Platform"
     }
   )

--- a/groups/infrastructure/main.tf
+++ b/groups/infrastructure/main.tf
@@ -2,16 +2,16 @@
 # Providers
 # ------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.13.0, < 0.14"
+  required_version = ">= 1.3, < 2.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 0.3, < 4.0"
+      version = ">= 5.0, < 6.0"
     }
     vault = {
       source  = "hashicorp/vault"
-      version = ">= 2.0.0"
+      version = ">= 4.0, < 5.0"
     }
   }
   backend "s3" {}
@@ -33,18 +33,16 @@ provider "vault" {
 ####################################################################################################
 ## IAM Password Policy
 ####################################################################################################
-
 module "iam_password_policy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/iam_password_policy?ref=tags/1.0.247"
+  source = "git@github.com:companieshouse/terraform-modules//aws/iam_password_policy?ref=tags/1.0.267"
 }
 
 ####################################################################################################
 ## CloudTrail CIS alerting
 ## Configures an SNS Topic and a number of metric filters and alarms to alert on specific changes.
 ####################################################################################################
-
 module "cloudtrail_cis_alerting" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/cloudtrail_cis_alerting?ref=tags/1.0.257"
+  source = "git@github.com:companieshouse/terraform-modules//aws/cloudtrail_cis_alerting?ref=tags/1.0.267"
 
   aws_profile    = "${var.aws_account}-${var.aws_region}"
   account        = var.account

--- a/groups/infrastructure/s3.tf
+++ b/groups/infrastructure/s3.tf
@@ -3,7 +3,7 @@
 ###################################
 module "heritage_staging_chips_backup" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "2.11.1"
+  version = "4.0.1"
 
   for_each = toset(local.db_names)
 
@@ -49,7 +49,7 @@ module "heritage_staging_chips_backup" {
 }
 
 module "heritage_staging_chips_backup_policy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/s3_cross_account_policy?ref=tags/1.0.137"
+  source = "git@github.com:companieshouse/terraform-modules//aws/s3_cross_account_policy?ref=tags/1.0.267"
 
   for_each = toset(local.db_names)
 
@@ -133,7 +133,7 @@ module "heritage_staging_chips_backup_policy" {
 ###################################
 module "heritage_live_chips_backup" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "2.11.1"
+  version = "4.0.1"
 
   for_each = toset(local.db_names)
 
@@ -179,7 +179,7 @@ module "heritage_live_chips_backup" {
 }
 
 module "heritage_live_chips_backup_policy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/s3_cross_account_policy?ref=tags/1.0.137"
+  source = "git@github.com:companieshouse/terraform-modules//aws/s3_cross_account_policy?ref=tags/1.0.267"
 
   for_each = toset(local.db_names)
 

--- a/groups/infrastructure/s3.tf
+++ b/groups/infrastructure/s3.tf
@@ -8,7 +8,6 @@ module "heritage_staging_chips_backup" {
   for_each = toset(local.db_names)
 
   bucket = "hstg-${each.value}-backup-${var.aws_account}-${var.aws_region}"
-  acl    = "private"
 
   block_public_acls       = true
   block_public_policy     = true
@@ -138,7 +137,6 @@ module "heritage_live_chips_backup" {
   for_each = toset(local.db_names)
 
   bucket = "hlive-${each.value}-backup-${var.aws_account}-${var.aws_region}"
-  acl    = "private"
 
   block_public_acls       = true
   block_public_policy     = true

--- a/groups/infrastructure/security.tf
+++ b/groups/infrastructure/security.tf
@@ -1,5 +1,5 @@
 module "config" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/config?ref=tags/1.0.63"
+  source = "git@github.com:companieshouse/terraform-modules//aws/config?ref=tags/1.0.267"
 
   name = "${var.account}-conf"
 
@@ -22,7 +22,7 @@ resource "aws_config_conformance_pack" "pci_dss" {
 }
 
 module "cloudtrail" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/cloudtrail?ref=tags/1.0.99"
+  source = "git@github.com:companieshouse/terraform-modules//aws/cloudtrail?ref=tags/1.0.267"
 
   trail_name     = "ct-${var.aws_account}-${var.region}-001"
   s3_bucket_name = local.security_s3["cloudtrail-bucket-name"]

--- a/groups/infrastructure/sessionmanager.tf
+++ b/groups/infrastructure/sessionmanager.tf
@@ -37,9 +37,9 @@ DOC
 
   tags = merge(
     local.default_tags,
-    map(
-      "Account", var.aws_account,
-      "ServiceTeam", "Network"
-    )
+    {
+      "Account" = var.aws_account,
+      "ServiceTeam" = "Network"
+    }
   )
 }

--- a/groups/infrastructure/sessionmanager.tf
+++ b/groups/infrastructure/sessionmanager.tf
@@ -38,7 +38,7 @@ DOC
   tags = merge(
     local.default_tags,
     {
-      "Account" = var.aws_account,
+      "Account"     = var.aws_account,
       "ServiceTeam" = "Network"
     }
   )


### PR DESCRIPTION
Updated `groups/infrastructure` Terraform and Provider versions
Bumped module versions to use TF 1.3-compatible modules
No longer apply bucket ACLs as object ownership config doesn't allow it
Replaced calls to deprecated `map` function
Various formatting/alignment updates